### PR TITLE
MERGE CREATE INSTANCE ID AS A REFERENCE ON START:

### DIFF
--- a/backend/app/src/admins/admins.module.ts
+++ b/backend/app/src/admins/admins.module.ts
@@ -6,10 +6,7 @@ import { AnonymousUserModule } from "../anonymous-user/anonyous-user.module";
 
 @Module({
 	imports: [AnonymousUserModule],
-	providers: [
-		AdminsService,
-		AnonymousUserService
-	],
+	providers: [AdminsService],
 	controllers: [AdminsController],
 	exports: [AdminsService]
 })

--- a/backend/app/src/anonymous-user/anonymous-user.controller.ts
+++ b/backend/app/src/anonymous-user/anonymous-user.controller.ts
@@ -28,7 +28,7 @@ import
 }	from "./anonymous-user.interface";
 import { AuthorizationGuard } from "./anonymous-user.authorizationGuard";
 import { Response } from "express";
-import { PrismaClient } from "@prisma/client";
+// import { PrismaClient } from "@prisma/client";
 
 class AnonymousRegisterDto
 {
@@ -53,7 +53,9 @@ export class AnonymousUserController
 	constructor(private readonly anonymousUserService: AnonymousUserService)
 	{
 		this.logger = new Logger("anonymous-user controller");
-		this.logger.debug("I'm connected :)");
+		this.logger
+		.debug("I'm connected to anonymous-user-service instance id :"
+			+ this.anonymousUserService.getUuidInstance());
 	}
 
 	@Post("register")
@@ -71,31 +73,6 @@ export class AnonymousUserController
 			retValue.toDB.lastConnection = -1;
 		res.send(retValue.res).status(200)
 			.end();
-		// res.send(retValue.res);
-		// const prisma = new PrismaClient();
-		// const	rec = retValue.toDB;
-		// prisma.$connect();
-		// prisma.anonymousUser.create({
-		// 	data:
-		// 	{
-		// 		uuid: rec.uuid,
-		// 		isRegistredAsRegularUser: rec.isRegistredAsRegularUser,
-		// 		lastConnection: rec.lastConnection as number,
-		// 		password: rec.password,
-		// 		revokeConnectionRequest: rec.revokeConnectionRequest,
-		// 		token: rec.token,
-		// 		userCreatedAt: rec.userCreatedAt
-		// 	}
-		// })
-		// 	.catch((error: any) =>
-		// 	{
-		// 		throw error;
-		// 	})
-		// 	.finally(async () =>
-		// 	{
-		// 		prisma.$disconnect();
-		// 	});
-		// return ;
 	}
 
 	@Post("login")

--- a/backend/app/src/anonymous-user/anonyous-user.module.ts
+++ b/backend/app/src/anonymous-user/anonyous-user.module.ts
@@ -4,7 +4,11 @@ import { AnonymousUserController } from "./anonymous-user.controller";
 
 
 @Module({
-	providers: [AnonymousUserService, AnonymousUserController],
+	providers:
+	[
+		AnonymousUserService,
+		AnonymousUserController
+	],
 	exports: [AnonymousUserService]
 })
 export class AnonymousUserModule

--- a/backend/app/src/anonymous-user/anonyous-user.module.ts
+++ b/backend/app/src/anonymous-user/anonyous-user.module.ts
@@ -4,10 +4,7 @@ import { AnonymousUserController } from "./anonymous-user.controller";
 
 
 @Module({
-	providers: [
-		AnonymousUserService,
-		AnonymousUserController // to test 
-	],
+	providers: [AnonymousUserService],
 	exports: [AnonymousUserService]
 })
 export class AnonymousUserModule

--- a/backend/app/src/app.controller.ts
+++ b/backend/app/src/app.controller.ts
@@ -12,7 +12,7 @@ export class AppController implements OnModuleInit
 
 	constructor(private readonly appService: AppService)
 	{
-		this.logger = new Logger("main controlelr");
+		this.logger = new Logger("main controller");
 	}
 
 	@Get("/server-status")

--- a/backend/app/src/app.module.ts
+++ b/backend/app/src/app.module.ts
@@ -1,9 +1,7 @@
 import { Module } from "@nestjs/common";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
-import {
-	AnonymousUserService
-} from "./anonymous-user/anonymous-user.service";
+
 import { AdminsModule } from "./admins/admins.module";
 import
 {

--- a/backend/app/src/app.module.ts
+++ b/backend/app/src/app.module.ts
@@ -31,14 +31,13 @@ import { AnonymousUserModule } from "./anonymous-user/anonyous-user.module";
 	],
 	controllers: [
 		AppController,
-		// AnonymousUserController,
+		AnonymousUserController,
 		AdminsController,
 		ChatApiController,
 		UserController
 	],
 	providers: [
 		AppService,
-		// AnonymousUserService,
 		UserService,
 		AdminsService,
 		ChatApiModule,

--- a/backend/app/src/chat-api/chat-api.controller.ts
+++ b/backend/app/src/chat-api/chat-api.controller.ts
@@ -8,7 +8,8 @@ export class ChatApiController
 	constructor(private readonly chatApiService: ChatApiService)
 	{
 		this.logger
-			.log("instanciate controller for the chat API's");
+			.log("instanciate controller for the chat API's with instance id:"
+				+ this.chatApiService.getUuidInstance());
 	}
 
 	@Get("all-user")

--- a/backend/app/src/chat-api/chat-api.service.ts
+++ b/backend/app/src/chat-api/chat-api.service.ts
@@ -15,4 +15,9 @@ export class ChatApiService
 	{
 		return (this.chatService.getAllUsers());
 	}
+
+	public getUuidInstance(): string
+	{
+		return (this.chatService.getChatInstanceId());
+	}
 }

--- a/backend/app/src/chat/Chat.service.ts
+++ b/backend/app/src/chat/Chat.service.ts
@@ -51,7 +51,7 @@ export	class ChatService
 {
 	// data here 
 	private	chat: Chat;
-	private	log = new Logger("instance-chat-service");
+	private	log = new Logger("instance-chat-service itself");
 	private	uuid = uuidv4();
 
 	constructor()

--- a/backend/app/src/chat/ChatSocketEvent.ts
+++ b/backend/app/src/chat/ChatSocketEvent.ts
@@ -8,7 +8,7 @@ import Chat from "./Objects/Chat";
 import User from "./Objects/User";
 import Channel from "./Objects/Channel";
 import { Prisma } from "@prisma/client";
-
+import { v4 as uuidv4 } from "uuid";
 import
 {
 	ConnectedSocket,
@@ -21,6 +21,7 @@ import
 	WebSocketServer
 }	from "@nestjs/websockets";
 import { ChatService } from "./Chat.service";
+import { Logger } from "@nestjs/common";
 
 type	ActionSocket = {
 	type: string,
@@ -58,9 +59,12 @@ export class ChatSocketEvents
 	{
 		@WebSocketServer()
 		server: Server;
+		private readonly logger = new Logger("Chat-socket-events");
 
 		public	constructor(private readonly chatService: ChatService)
 		{
+			this.logger.debug("An instance is started with chat service id: "
+				+ this.chatService.getChatInstanceId());
 		}
 
 		afterInit(server: any)

--- a/backend/app/src/user/user.authorizationGuard.ts
+++ b/backend/app/src/user/user.authorizationGuard.ts
@@ -5,6 +5,7 @@ import {
 	CanActivate,
 	ExecutionContext,
 	Injectable,
+	Logger,
 	UnauthorizedException
 }	from "@nestjs/common";
 import { Observable } from "rxjs";
@@ -21,9 +22,10 @@ import {
 @Injectable()
 export	class UserAuthorizationGuard implements CanActivate
 {
+	private readonly logger = new Logger("User-Auth-guard");
 	constructor(private readonly service: UserService)
 	{
-
+		this.logger.log("UserAuthorizationGuard instance created with instance id : " + this.service.getUuidInstance());
 	}
 
 	private	isValidTokenSignature(token: string, secret: string)

--- a/backend/app/src/user/user.controller.ts
+++ b/backend/app/src/user/user.controller.ts
@@ -3,19 +3,13 @@
 /* eslint-disable max-lines-per-function */
 /* eslint-disable max-statements */
 /* eslint-disable max-classes-per-file */
-import { Body, Controller, Get,Logger, Post, Req, Res, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, Logger, Post, Req } from "@nestjs/common";
 import { UserService } from "./user.service";
-import { IsEmail, IsNotEmpty, IsUUID } from "class-validator";
-import { Response } from "express";
-import { PrismaClient } from "@prisma/client";
+import { IsEmail, IsNotEmpty, } from "class-validator";
 
 import	Api from "../Api";
-import axios, { AxiosRequestConfig } from "axios";
-import qs from "qs";
-import { error } from "console";
-import { ApplicationUserModel, UserLoginResponseModel, UserModel, UserRegisterResponseModel, UserVerifyTokenResModel } from "./user.interface";
-import { register } from "module";
-import { AuthorizationGuard } from "src/anonymous-user/anonymous-user.authorizationGuard";
+
+import { ApplicationUserModel, UserLoginResponseModel, UserModel, UserVerifyTokenResModel } from "./user.interface";
 
 class	RegisterDto
 {
@@ -48,7 +42,7 @@ export class UserController
 	constructor(private readonly userService: UserService)
 	{
 		this.logger = new Logger("user-controller");
-		this.logger.log("instance loaded");
+		this.logger.log("instance UserService loaded with the instance id: " + this.userService.getUuidInstance());
 	}
 
 	@Post("register")
@@ -218,7 +212,7 @@ export class UserController
 	}
 
 	@Post("verify-token")
-	@UseGuards(UserAuthorizationGuard)
+	// @UseGuards(UserAuthorizationGuard)
 	verifyToken(@Req() headers: {authorization?: string})
 		: UserVerifyTokenResModel
 	{

--- a/backend/app/src/user/user.service.ts
+++ b/backend/app/src/user/user.service.ts
@@ -4,7 +4,8 @@ import
 {
 	BadRequestException,
 	ForbiddenException,
-	Injectable } from "@nestjs/common";
+	Injectable, 
+	Logger} from "@nestjs/common";
 import
 {
 	AdminResponseModel,
@@ -21,8 +22,21 @@ import	* as jwt from "jsonwebtoken";
 @Injectable()
 export class UserService
 {
-	private user: Array<UserModel> = [];
+	private	user: Array<UserModel> = [];
 	private	secret = randomBytes(64).toString("hex");
+	private readonly logger = new Logger("user-service itself");
+	private readonly uuidInstance = uuidv4();
+
+	public constructor()
+	{
+		this.logger.log("Base instance loaded with the instance id: "
+			+ this.getUuidInstance());
+	}
+
+	public	getUuidInstance(): string
+	{
+		return (this.uuidInstance);
+	}
 
 	public	getUserArray(): Array<UserModel>
 	{
@@ -35,7 +49,6 @@ export class UserService
 		{
 			return ({
 				...elem,
-				// TEST
 				password: "[hidden information]"
 			});
 		});
@@ -67,10 +80,6 @@ export class UserService
 				url: data.url,
 				avatar: data.avatar,
 				location: data.location,
-				// uuid: data.uuid,
-				// // TEST anonymous user pw
-				// password: data.password,
-				// createdAt: data.createdAt,
 				authService:
 				{
 					token: "Bearer " + jwt.sign(
@@ -99,10 +108,6 @@ export class UserService
 				message: "Your session has been created, you must loggin",
 				token: newUser.authService.token,
 				statusCode: newUser.retStatus
-				// uuid: newUser.uuid,
-				// password: newUser.password,
-				// creationDate: newUser.createdAt,
-				// statusCode: newUser.retStatus
 			};
 			console.log("user service newUser 78: ", newUser);
 			console.log(" ");

--- a/backend/app/src/user/user.service.ts
+++ b/backend/app/src/user/user.service.ts
@@ -4,8 +4,10 @@ import
 {
 	BadRequestException,
 	ForbiddenException,
-	Injectable, 
-	Logger} from "@nestjs/common";
+	Injectable,
+	InternalServerErrorException,
+	Logger
+} from "@nestjs/common";
 import
 {
 	AdminResponseModel,


### PR DESCRIPTION
When service is shared across another modules
like service-wrapper (connect socket to http)
we need to verify the id of the instance.
No need for no-exported service but good practice to do log of id in case of connection of the service.

Example of expected output to check when we use a service inside another class.
```
[Nest] 39  - 10/06/2023, 7:46:01 PM   DEBUG [anymous-user-service itself] An instance of service is started with id:           dbaabe24-7602-4f14-8963-7a1cbb9b2429
[Nest] 39  - 10/06/2023, 7:46:01 PM   DEBUG [anonymous-user controller] I'm connected to anonymous-user-service instance id :  dbaabe24-7602-4f14-8963-7a1cbb9b2429
[Nest] 39  - 10/06/2023, 7:46:01 PM   DEBUG [ADMIN] Admin start with anonymous-user-service instance id                        dbaabe24-7602-4f14-8963-7a1cbb9b2429
[Nest] 39  - 10/06/2023, 7:46:01 PM   DEBUG [ADMIN] Admin start with anonymous-user-service instance id                        dbaabe24-7602-4f14-8963-7a1cbb9b2429
[Nest] 39  - 10/06/2023, 7:46:01 PM     LOG [user-service itself] Base instance loaded with the instance id:      e454af45-08e2-4554-a83d-439c52311cce
[Nest] 39  - 10/06/2023, 7:46:01 PM     LOG [user-controller] instance UserService loaded with the instance id:   e454af45-08e2-4554-a83d-439c52311cce

[Nest] 39  - 10/06/2023, 7:46:01 PM     LOG [instance-chat-service] started service instance - id instance : ac126404-bc6a-43f4-a3cd-794143c254fd
[Nest] 39  - 10/06/2023, 7:46:01 PM     LOG [api-chat-service] adapter of websocket instance id :            ac126404-bc6a-43f4-a3cd-794143c254fd

```

**After pending merge #104**
now data is correct, was little confusing but when create a feature that use service, please log instance id and check carrefully

now example expected output:
```[Nest] 38  - 10/06/2023, 8:56:35 PM     LOG [user-service itself] Base instance loaded with the instance id:    5a3eebbc-6f6c-4e7d-9b55-d8839b76604c
[Nest] 38  - 10/06/2023, 8:56:35 PM     LOG [user-controller] instance UserService loaded with the instance id: 5a3eebbc-6f6c-4e7d-9b55-d8839b76604c

[Nest] 38  - 10/06/2023, 8:56:35 PM   DEBUG [ADMIN] Admin start with anonymous-user-service instance id                         fe3d892b-6fe4-4369-a3ea-15700cc310e7
[Nest] 38  - 10/06/2023, 8:56:35 PM   DEBUG [anymous-user-service itself] An instance of service is started with id:            fe3d892b-6fe4-4369-a3ea-15700cc310e7
[Nest] 38  - 10/06/2023, 8:56:35 PM   DEBUG [anonymous-user controller] I'm connected to anonymous-user-service instance id :   fe3d892b-6fe4-4369-a3ea-15700cc310e7
[Nest] 38  - 10/06/2023, 8:56:35 PM   DEBUG [ADMIN] Admin start with anonymous-user-service instance id                         fe3d892b-6fe4-4369-a3ea-15700cc310e7

[Nest] 38  - 10/06/2023, 8:56:35 PM     LOG [instance-chat-service itself] started service instance - id instance :             1f5f874b-4c8d-481b-9237-86cb09725a59
[Nest] 38  - 10/06/2023, 8:56:35 PM     LOG [api-chat-controller] instanciate controller for the chat API's with instance id:   1f5f874b-4c8d-481b-9237-86cb09725a59
[Nest] 38  - 10/06/2023, 8:56:35 PM   DEBUG [Chat-socket-events] An instance is started with chat service id:                   1f5f874b-4c8d-481b-9237-86cb09725a59
[Nest] 38  - 10/06/2023, 8:56:35 PM     LOG [api-chat-service] adapter of websocket instance id :                               1f5f874b-4c8d-481b-9237-86cb09725a59

```